### PR TITLE
Vendor HEE policy under prompts/hee @ d9330db60f4f098244eb5b6b084142c…

### DIFF
--- a/docs/hee/VERSION.md
+++ b/docs/hee/VERSION.md
@@ -1,2 +1,1 @@
-HEE upstream commit: 796d252a366d30e3f673bc8ed60ef5a482de6d4e
-Imported: 2026-01-24T18:58:44Z
+HEE upstream commit: d9330db60f4f098244eb5b6b084142c23d40f1c0

--- a/prompts/hee/docs/CONSUMERS.yml
+++ b/prompts/hee/docs/CONSUMERS.yml
@@ -1,0 +1,15 @@
+# Canonical registry of repositories using the Human Execution Engine (HEE)
+#
+# This file is machine-readable and authoritative.
+# The README list is derived and human-facing.
+#
+# Rules:
+# - Append new consumers only (do not reorder)
+# - Do not include timestamps
+# - Do not embed doctrine here
+
+consumers:
+  - repo: spencerbutler/market-thesis-news
+    mode: vendored
+    policy_version_path: docs/hee/VERSION.md
+    vendor_tool: tooling/bin/hee-vendor

--- a/prompts/hee/docs/hee/providers/GROQ_MODELS.yml
+++ b/prompts/hee/docs/hee/providers/GROQ_MODELS.yml
@@ -1,0 +1,38 @@
+# Groq model mapping (Free tier)
+# Keep this file small and deterministic. No timestamps.
+# Populate model IDs from: GET https://api.groq.com/openai/v1/models
+
+provider: groq
+tier: free
+model_policy:
+  primary_execution:
+    class: small_instruct
+    model_id: "llama-3.1-8b-instant" # selected from /openai/v1/models
+    usage:
+      - doc_edits
+      - formatting
+      - vendoring_checks
+      - small_diffs
+  escalation_planning:
+    class: large_instruct
+    model_id: "llama-3.3-70b-versatile" # selected from /openai/v1/models
+    constraints:
+      - single_pass_only
+      - plan_or_review_only
+    usage:
+      - one_shot_plan
+      - careful_review
+  secondary_reasoning:
+    class: medium_moe
+    model_id: "meta-llama/llama-4-scout-17b-16e-instruct" # selected from /openai/v1/models (optional middle gear)
+    usage:
+      - multi_file_light_planning
+      - cross_file_synthesis_small_scope
+
+rate_limit_policy:
+  on_429:
+    - retry_once
+    - abort_on_second_429
+output_limits:
+  default_max_lines: 150
+  prefer_split_steps_over_long_outputs: true

--- a/scripts/hee-check.sh
+++ b/scripts/hee-check.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Consumer-side HEE freshness check (template)
+# Assumes HEE is vendored into the consumer repo and exposes docs/hee/VERSION.md.
+
+EXPECTED_VERSION_FILE="docs/hee/VERSION.md"
+
+if [[ ! -f "$EXPECTED_VERSION_FILE" ]]; then
+  echo "ERROR: $EXPECTED_VERSION_FILE not found."
+  echo "HEE policy may not be vendored correctly."
+  exit 2
+fi
+
+VENDORED_VERSION="$(sed -n '1p' "$EXPECTED_VERSION_FILE" | tr -d '[:space:]')"
+
+if [[ -z "$VENDORED_VERSION" ]]; then
+  echo "ERROR: $EXPECTED_VERSION_FILE is empty or malformed."
+  exit 3
+fi
+
+echo "OK: Vendored HEE version detected: $VENDORED_VERSION"


### PR DESCRIPTION
…23d40f1c0

## Summary
Describe what this PR changes and why.

## Scope
- [ ] Docs only
- [ ] Prompts only
- [ ] Code (requires prompts/spec already merged to main)
- [ ] Tests
- [ ] CI / pre-commit

## Acceptance Criteria
List measurable criteria this PR meets.

## Risk / Safety
- Any commands beyond "safe" (no sudo)? If yes, justify and list.
- Any new dependencies? If yes, provide clear value justification and alternatives considered.

## Testing
- [ ] Not applicable (docs/prompts only)
- [ ] Unit
- [ ] Integration
- [ ] API contract
- [ ] UI smoke

## Model Disclosure
Commit messages in this PR include: `[model: ...]`

---

## Prompt Sync Check (Required if prompts/ changed)

- [ ] `prompts/` is the canonical source of truth
- [ ] Corresponding `.cursor/prompts/` wrapper stubs were updated in the same commit
- [ ] No authoritative instructions exist in `.cursor/prompts/`

