### PR TITLE
fix(docs): restore real README (bulk-template wipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,226 @@
-# tick-task
+# tick-task 🎯
 
-This repository is a verified component of the **Twin-Cities-Open-Systems (TCOS)** architecture.
+[![CI/CD Pipeline](https://github.com/spencerbutler/tick-task/actions/workflows/ci.yml/badge.svg)](https://github.com/spencerbutler/tick-task/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Node 16+](https://img.shields.io/badge/node-16+-green.svg)](https://nodejs.org/)
 
-* **Ecosystem Role:** [Insert the precise Purpose we defined in the master index]
-* **Visibility Standard:** [Public | Private -> Public | Very Private]
+> **Task management foundation for the Market Thesis ecosystem**
+>
+> A local-first task tracking application providing core task management capabilities for the broader Market Thesis platform, alongside tools like **MT-logo-render** for logo generation and **market-thesis** for the main platform. Zero external dependencies, full offline capability, and comprehensive security.
+
+## 🤖 Quick Agent Bootstrap
+**For AI Models & Agents - Get productive in 5 minutes:**
+
+### 📚 **Immediate Context**
+1. **📖 [SPEC.md](docs/SPEC.md)** - Complete requirements & acceptance criteria
+2. **🛣️ [ROADMAP.md](docs/ROADMAP.md)** - Current status & implementation phases
+3. **📝 [prompts/](prompts/)** - 18 complete implementation prompts (00-17)
+
+### 🎯 **Fastest Start**
+```bash
+# 1. Read the current phase status
+cat docs/ROADMAP.md | grep -A 5 "Phase.*COMPLETED\|Phase.*In Progress"
+
+# 2. Check available prompts
+ls prompts/ | head -10
+
+# 3. Read the relevant prompt for current work
+cat prompts/$(ls prompts/ | grep $(cat docs/ROADMAP.md | grep "Phase.*In Progress" | sed 's/.*Phase \([0-9]\).*/\1/') | head -1)
+```
+
+### 📋 **Development Workflow**
+- **📖 Read docs first** - All decisions documented with rationale
+- **📝 Follow prompts** - Step-by-step implementation guides
+- **🧪 Test thoroughly** - 65%+ coverage required
+- **📝 Document decisions** - Use ADR template for major changes
+- **🔄 Manual review** - PRs require human approval
+
+### 🎪 **Key Features**
+- **Complete context** without session history dependency
+- **Decision rationale** for all architectural choices
+- **Step-by-step guides** for consistent implementation
+- **Quality gates** ensure production readiness
+
+## ✨ Features
+
+### 🎯 **Core Functionality**
+- **Complete CRUD Operations** - Create, read, update, delete tasks with full validation
+- **Flexible Organization** - Context-based grouping (personal/professional/mixed)
+- **Smart Filtering** - Status, priority, due dates, tags, and custom queries
+- **Real-time Updates** - Instant synchronization across the application
+- **Export Capabilities** - JSON and CSV export for backup and portability
+
+### 🔒 **Security & Privacy**
+- **Local-First Design** - All data stays on your device, zero cloud dependency
+- **Comprehensive Validation** - Input sanitization, Unicode safety, and injection protection
+- **LAN Mode** (Optional) - Secure token-based access for local network sharing
+- **No Telemetry** - Your data and usage patterns remain completely private
+
+### 🎨 **User Experience**
+- **Modern Web Interface** - Responsive React application with dark/light themes
+- **Keyboard Shortcuts** - Power user efficiency with intuitive hotkeys
+- **Inline Editing** - Quick task modifications without navigation
+- **Rich Text Support** - Markdown formatting in task descriptions
+- **Accessibility First** - WCAG 2.1 AA compliant interface
+
+### 🛠️ **Developer Experience**
+- **Comprehensive Testing** - 81+ test cases with 65%+ coverage
+- **Type Safety** - Full TypeScript coverage with strict typing
+- **API Documentation** - Auto-generated OpenAPI/Swagger documentation
+- **Development Tools** - Pre-commit hooks, linting, and automated quality gates
+
+## 🚀 Quick Start
+
+### Prerequisites
+- **Python 3.9+** - Backend runtime
+- **Node.js 16+** - Frontend development
+- **Git** - Version control
+- **aiosqlite** - Async SQLite driver (installed automatically)
+
+### Installation & Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/spencerbutler/tick-task.git
+cd tick-task
+
+# One-command development setup (recommended)
+./dev.py
+
+# Or manual setup:
+# pip install -e .
+# python -m alembic upgrade head
+# cd frontend && npm install && npm run build
+
+# Development server
+python src/tick_task/main.py  # Backend on :8000
+cd frontend && npm run dev    # Frontend on :5173
+```
+
+Visit **http://localhost:5173** to access the application!
+
+## 📖 Documentation
+
+### 📋 **Core Documentation**
+- [**📖 Specification**](docs/SPEC.md) - Complete requirements and acceptance criteria
+- [**🏗️ Architecture**](docs/ARCHITECTURE.md) - System design and technical decisions
+- [**🔌 API Reference**](docs/API.md) - REST API documentation and examples
+- [**🧪 Testing Strategy**](docs/TESTING.md) - Quality assurance and test coverage
+
+### 🗺️ **Project Management**
+- [**🛣️ Implementation Roadmap**](docs/ROADMAP.md) - Phase-by-phase development plan
+- [**🔐 Security Guide**](docs/SECURITY.md) - Security posture and operational guidance
+- [**💾 Data Model**](docs/DATA_MODEL.md) - Database schema and entity relationships
+
+### 🤖 **AI Development**
+- [**📝 Prompt Library**](prompts/) - Complete 18-prompt implementation suite
+- [**📋 Decision Records**](docs/ADRs/) - Architecture decision rationale
+- [**⚙️ Development Setup**](DEV_SETUP.md) - Environment configuration guide
+
+## 🎨 Screenshots
+
+### Task Management Interface
+*Beautiful, intuitive task management with inline editing and rich formatting*
+
+### Advanced Filtering
+*Powerful query system supporting complex task organization*
+
+### API Documentation
+*Comprehensive OpenAPI documentation for ecosystem integration*
+
+## 🏗️ Architecture
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│   React UI      │    │  FastAPI        │    │   SQLite DB     │
+│   (TypeScript)  │◄──►│  (Python)       │◄──►│   (SQLAlchemy)  │
+│                 │    │                 │    │                 │
+│ • Task Views    │    │ • REST API      │    │ • Tasks Table   │
+│ • Inline Edit   │    │ • Validation     │    │ • Migrations    │
+│ • Markdown      │    │ • Security       │    │ • Indexes       │
+│ • Responsive    │    │ • Export         │    │ • Constraints   │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+```
+
+### Technology Stack
+
+| Component | Technology | Purpose |
+|-----------|------------|---------|
+| **Frontend** | React + TypeScript | User interface and interactions |
+| **Backend** | FastAPI + Python | REST API and business logic |
+| **Database** | SQLite + SQLAlchemy | Data persistence and queries |
+| **Styling** | Tailwind CSS | Responsive design system |
+| **Testing** | pytest + Vitest | Comprehensive test coverage |
+| **Security** | SecurityValidator | Input sanitization and validation |
+
+## 🤝 Contributing
+
+### Development Workflow
+1. **📖 Read the Docs** - Start with [SPEC.md](docs/SPEC.md) and [ROADMAP.md](docs/ROADMAP.md)
+2. **🍴 Fork & Branch** - Create feature branches from `main`
+3. **💻 Implement** - Follow the prompt library for consistent implementation
+4. **🧪 Test** - Ensure all tests pass and coverage maintained
+5. **📝 Document** - Update relevant documentation and decision records
+6. **🔄 PR** - Create pull request with comprehensive description
+7. **👀 Review** - Manual code review and testing verification
+8. **✅ Merge** - Approved changes merged to main
+
+### Code Quality Standards
+- **Type Safety** - Full TypeScript/Python typing
+- **Test Coverage** - Minimum 65% with comprehensive test suite
+- **Security** - All inputs validated, no injection vulnerabilities
+- **Documentation** - Code comments, API docs, and user guides
+- **Performance** - Startup <5s, API responses <100ms
+
+## 📊 Project Status
+
+### ✅ **Completed Phases**
+- **Phase 1**: Spec & Architecture ✅
+- **Phase 2**: Design & Strategy ✅
+- **Inline Task Editing**: Complete ✅
+
+### 🚧 **Current Phase**
+- **Phase 3**: Foundation Planning (In Progress)
+
+### 🎯 **Quality Metrics**
+- **Test Coverage**: 65% (81 test cases)
+- **Security**: Comprehensive validation implemented
+- **Performance**: Meets all targets
+- **Accessibility**: WCAG 2.1 AA compliant
+
+## 📄 License
+
+**MIT License** - see [LICENSE](LICENSE) file for details.
+
+## 🙏 Acknowledgments
+
+- **Market Thesis Ecosystem** - Integrated task management foundation alongside MT-logo-render and market-thesis
+- **Open Source Community** - React, FastAPI, SQLite, and countless libraries
+- **AI Development** - Claude, GPT, and other models contributing to this implementation
+
+## 📞 Support
+
+- **📖 Documentation**: Comprehensive guides in the `docs/` directory
+- **🐛 Issues**: [GitHub Issues](https://github.com/spencerbutler/tick-task/issues)
+- **💬 Discussions**: [GitHub Discussions](https://github.com/spencerbutler/tick-task/discussions)
+- **🔒 Security**: See [SECURITY.md](docs/SECURITY.md) for responsible disclosure
 
 ---
 
-## 🛠️ Global Alignment & Invariants
+## 📈 **Development Efficiency Showcase**
 
-This codebase strictly adheres to the core engineering principles, scripting standards, and structural invariants mandated by the organization. 
+*This project demonstrates the power of AI-orchestrated development:*
 
-* **Scripting Guardrails:** All userland scripts (`.sh`, `.py`, `.awk`) inside this repository enforce the portable shebang syntax and a mandatory 4-line metadata header block.
-* **Terminology & Definitions:** Operational concepts, naming matrices, and architectural definitions match our centralized single source of truth.
+| Metric | Achievement | Traditional Equivalent |
+|--------|-------------|----------------------|
+| **Cost Efficiency** | **1,270x - 1,872x cheaper** | $400k - $700k project cost |
+| **Development Speed** | **6-9x faster** | 19-28 weeks → 3-4 weeks |
+| **Resource Usage** | **38-84x more efficient** | 8-12 person team → 1 orchestrator |
+| **Quality Standards** | **Industry leading** | Security, accessibility, documentation |
 
-For complete compliance blueprints, operational roadmaps, and the global architecture manifest, refer back directly to the primary [TCOS Command Center Config](../.github).
+**Delivered by expert AI orchestration - available for your next project.** 🚀
 
 ---
 
-## 📜 Governance & Guidelines
-Contributions, architectural proposals, and documentation changes inside this node must follow our organizational frameworks. Review our global guidelines in the centralized [TCOS Glossary](../.github/blob/main/profile/GLOSSARY.md).
-
+**Built with ❤️ for productivity and privacy**


### PR DESCRIPTION
Same pattern as fleet-ops#195/HEE#245 -- the org-wide bulk doc update replaced this repo's real README with the generic template, unfilled placeholders included. Restored the real content.