### PR TITLE
fix(build): manualChunks must be a function under vite 8 / rolldown

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,10 +19,24 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom'],
-          router: ['react-router-dom'],
-          query: ['@tanstack/react-query'],
+        // Function form, not the object form. vite 8 bundles with rolldown
+        // rather than rollup, and rolldown rejects an object outright:
+        // "TypeError: manualChunks is not a function". Same three chunks,
+        // same members.
+        //
+        // Order matters: 'react-router-dom' and '@tanstack/react-query' both
+        // contain 'react', so they must be matched BEFORE the vendor test or
+        // they would collapse into it.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return;
+          // 'react-router', not 'react-router-dom': v6+ react-router-dom is a
+          // thin re-export and the actual code resolves under
+          // node_modules/react-router/, which does not contain the '-dom'
+          // suffix. Matching the longer name put the router in the main
+          // bundle instead of its own chunk.
+          if (id.includes('react-router')) return 'router';
+          if (id.includes('@tanstack/react-query')) return 'query';
+          if (id.includes('react-dom') || id.includes('/react/')) return 'vendor';
         },
       },
     },


### PR DESCRIPTION
## Follow-up to #40 — that merge raced my push

This fix was pushed to the `#40` branch but the merge landed first, so `main`
still carries the object form and **`Build frontend` still fails**.

## The failure

Fixing the Node version in
https://github.com/Twin-Cities-Open-Systems/tick-task/pull/40 let CI reach the
build step for the first time:

```
TypeError: manualChunks is not a function
```

`vite 8` bundles with **rolldown**, not rollup, and rolldown rejects the object
form outright.

## Two ordering traps, both caught by verifying

**1.** `react-router-dom` and `@tanstack/react-query` both *contain* `react`,
so they must be matched **before** the vendor test or they collapse into it.

**2.** Matching `'react-router-dom'` **does not work.** v6+ `react-router-dom`
is a thin re-export; the real code resolves under `node_modules/react-router/`,
with no `-dom` suffix. My first attempt built cleanly and silently put the
entire router in the main bundle — caught only by grepping the built assets
and finding `react-router` inside `index` rather than a `router` chunk.

## Verified

```
dist/assets/query-B0VU7A7x.js     34.48 kB
dist/assets/router-CvPdQfvz.js    37.66 kB   <- present, and holds the router
dist/assets/vendor-CJoAVRn8.js   132.79 kB
dist/assets/index-CiwNgRIe.js    143.55 kB
✓ built
```

Plus 5 tests passing.

## Still open after this

`quality-check` remains red on pre-existing formatting debt — `black` (13 of 24
python files), `isort` (12), and `eslint 8.57.1` failing to load its own
config. Unrelated to this or #40; needs its own PR.
