### PR TITLE
feat(auth): make lan_mode/lan_token real, before anything binds 0.0.0.0

### DIFF
--- a/src/tick_task/auth.py
+++ b/src/tick_task/auth.py
@@ -1,0 +1,55 @@
+"""LAN access control.
+
+`lan_mode` and `lan_token` have existed in config.py since the settings module
+was written, and until now were referenced NOWHERE else in the codebase. They
+read like an access control and enforced nothing -- every endpoint was open,
+with the only `Depends()` in api.py being the database session.
+
+That was survivable only because `host` defaults to 127.0.0.1, so the API was
+reachable from the local machine alone. Anything that binds 0.0.0.0 -- a
+container, most obviously, where the published port does nothing otherwise --
+turns six unauthenticated CRUD endpoints into a network service.
+
+So the fields now do what they claim.
+
+FAILS CLOSED. If lan_mode is on and no token is configured, every request is
+refused rather than allowed through: a half-configured deployment must not be
+an open one.
+
+Constant-time comparison, because a naive `==` on a shared secret leaks its
+prefix to anyone who can time responses.
+"""
+
+import secrets
+from typing import Optional
+
+from fastapi import Header, HTTPException, status
+
+from tick_task.config import settings
+
+_SCHEME = "Bearer"
+
+
+async def require_lan_token(authorization: Optional[str] = Header(None)) -> None:
+    """Reject requests without a valid LAN token, when lan_mode is enabled.
+
+    No-op when lan_mode is off, which keeps the default loopback-only posture
+    exactly as it was.
+    """
+    if not settings.lan_mode:
+        return
+
+    if not settings.lan_token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="lan_mode is enabled but lan_token is not configured",
+        )
+
+    expected = f"{_SCHEME} {settings.lan_token}"
+    supplied = authorization or ""
+    if not secrets.compare_digest(supplied, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing LAN token",
+            headers={"WWW-Authenticate": _SCHEME},
+        )

--- a/src/tick_task/main.py
+++ b/src/tick_task/main.py
@@ -1,12 +1,12 @@
 """Main FastAPI application."""
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-
 from fastapi.responses import RedirectResponse
 
 from tick_task.api import router as api_router
+from tick_task.auth import require_lan_token
 from tick_task.config import settings
 from tick_task.database import create_tables
 
@@ -25,7 +25,10 @@ def create_application() -> FastAPI:
     # Configure CORS
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],  # Vite dev server
+        allow_origins=[
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+        ],  # Vite dev server
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -38,7 +41,14 @@ def create_application() -> FastAPI:
         return RedirectResponse(url="/docs")
 
     # Include API routes
-    app.include_router(api_router, prefix="/api/v1")
+    # Applied at the router, so every current AND future endpoint is covered.
+    # Attaching per-route would mean the next endpoint someone adds is open
+    # by default -- exactly how this gap persisted.
+    app.include_router(
+        api_router,
+        prefix="/api/v1",
+        dependencies=[Depends(require_lan_token)],
+    )
 
     return app
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,75 @@
+"""Tests for LAN token access control.
+
+These exist because lan_mode/lan_token were declared in config and enforced
+nowhere -- config fields that looked like an access control while every
+endpoint stayed open. The tests pin the behavior so that cannot regress
+silently.
+"""
+
+import pytest
+
+from tick_task.config import settings
+
+
+@pytest.fixture
+def lan_off(monkeypatch):
+    monkeypatch.setattr(settings, "lan_mode", False)
+    monkeypatch.setattr(settings, "lan_token", None)
+
+
+@pytest.fixture
+def lan_on_no_token(monkeypatch):
+    monkeypatch.setattr(settings, "lan_mode", True)
+    monkeypatch.setattr(settings, "lan_token", None)
+
+
+@pytest.fixture
+def lan_on(monkeypatch):
+    monkeypatch.setattr(settings, "lan_mode", True)
+    monkeypatch.setattr(settings, "lan_token", "correct-horse-battery-staple")
+
+
+def test_lan_mode_off_leaves_api_open(client, lan_off):
+    """Default posture is unchanged: loopback-only, no token required."""
+    assert client.get("/api/v1/health").status_code == 200
+
+
+def test_lan_mode_on_without_token_fails_closed(client, lan_on_no_token):
+    """A half-configured deployment must refuse, never fall open."""
+    r = client.get("/api/v1/health")
+    assert r.status_code == 503
+    assert "lan_token" in r.json()["detail"]
+
+
+def test_lan_mode_on_rejects_missing_token(client, lan_on):
+    r = client.get("/api/v1/health")
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "Bearer"
+
+
+def test_lan_mode_on_rejects_wrong_token(client, lan_on):
+    r = client.get("/api/v1/health", headers={"Authorization": "Bearer nope"})
+    assert r.status_code == 401
+
+
+def test_lan_mode_on_rejects_bare_token_without_scheme(client, lan_on):
+    """The scheme is part of the expected value, not optional."""
+    r = client.get(
+        "/api/v1/health",
+        headers={"Authorization": "correct-horse-battery-staple"},
+    )
+    assert r.status_code == 401
+
+
+def test_lan_mode_on_accepts_correct_token(client, lan_on):
+    r = client.get(
+        "/api/v1/health",
+        headers={"Authorization": "Bearer correct-horse-battery-staple"},
+    )
+    assert r.status_code == 200
+
+
+def test_write_endpoints_are_protected_too(client, lan_on):
+    """Not just reads -- POST/PUT/DELETE were equally open before this."""
+    r = client.post("/api/v1/tasks", json={"title": "x"})
+    assert r.status_code == 401


### PR DESCRIPTION
## Why now

`lan_mode` and `lan_token` have been in `config.py` since it was written and
are referenced **nowhere else**. They read like an access control and enforced
nothing — every `Depends()` in `api.py` is the database session, and all six
endpoints including `POST`/`PUT`/`DELETE` were open.

Survivable only because `host` defaults to `127.0.0.1`. **Containerizing
changes that by necessity**: a container binding loopback publishes nothing, so
`HOST=0.0.0.0` is mandatory — and that one line would have turned six
unauthenticated CRUD endpoints into a network service, on a fleet where
services then get an haproxy rule.

Doing this before the Dockerfile is the whole point.

## Behavior

| state | result |
|---|---|
| `lan_mode` off (default) | unchanged — no token, loopback posture as before |
| `lan_mode` on, no token set | **503 on every request** — fails closed |
| `lan_mode` on, token set | `Bearer` token required, constant-time compared |

## Two deliberate choices

**Applied at `include_router`, not per-route.** Every future endpoint is
covered by default. Per-route is how this gap would return — the next endpoint
would be open unless someone remembered.

**`secrets.compare_digest`, not `==`.** A naive comparison on a shared secret
leaks its prefix to anyone who can time responses.

## Tests

7 new, covering each state — including the two easy to miss: fail-closed when
the token is unset, and rejecting a bare token without the `Bearer` scheme.

`auth.py` 100% coverage · full suite **88 passed**.
