### PR TITLE
fix(ci): unbreak main -- mypy continue-on-error per rule 16, plus two config defects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,17 @@ jobs:
         black --check --diff .
         isort --check-only --diff .
 
+    # continue-on-error per PROMPTING_RULES rule 16: never land a check that is
+    # red on day one. This one is red on 18 PRE-EXISTING type errors that #42
+    # merely unmasked -- it was never reached before, because an earlier step in
+    # this job always failed first. The errors are real debt, not noise, and are
+    # tracked; failing the build on them would only train people to ignore red.
+    #
+    # FLIP CONDITION: remove continue-on-error as soon as the tracked debt issue
+    # is closed and `mypy src/ --ignore-missing-imports` exits 0 locally. Do not
+    # hardcode a target count here -- new code changes it.
     - name: Run type checking
+      continue-on-error: true
       run: |
         mypy src/ --ignore-missing-imports
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,11 @@ skip = ["__init__.py"]
 
 # mypy type checking
 [tool.mypy]
-python_version = "3.9"
+# 3.10 is the lowest mypy still accepts -- it rejects 3.9 outright
+# ("Python 3.9 is not supported (must be 3.10 or higher)") and printed
+# that on every run. requires-python is still >=3.9, so mypy no longer
+# checks against the declared floor; see the type-debt issue.
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -118,10 +122,6 @@ warn_no_return = true
 warn_unreachable = true
 strict_equality = true
 show_error_codes = true
-
-[[tool.mypy.overrides]]
-module = ["alembic.*"]
-ignore_missing_imports = true
 
 # pytest configuration
 [tool.pytest.ini_options]

--- a/src/tick_task/api.py
+++ b/src/tick_task/api.py
@@ -8,7 +8,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tick_task.config import settings
 from tick_task.database import get_db
 from tick_task.models import Task
 from tick_task.schemas import ErrorResponse, HealthResponse
@@ -201,7 +200,10 @@ async def delete_task(
     "/tasks",
     response_model=TaskList,
     summary="List tasks",
-    description="Retrieve a list of tasks with optional filtering, sorting, and pagination",
+    description=(
+        "Retrieve a list of tasks with optional filtering, sorting, "
+        "and pagination"
+    ),
 )
 async def list_tasks(
     # Filtering parameters

--- a/src/tick_task/api.py
+++ b/src/tick_task/api.py
@@ -201,8 +201,7 @@ async def delete_task(
     response_model=TaskList,
     summary="List tasks",
     description=(
-        "Retrieve a list of tasks with optional filtering, sorting, "
-        "and pagination"
+        "Retrieve a list of tasks with optional filtering, sorting, and pagination"
     ),
 )
 async def list_tasks(

--- a/src/tick_task/config.py
+++ b/src/tick_task/config.py
@@ -1,6 +1,5 @@
 """Application configuration."""
 
-import os
 from pathlib import Path
 from typing import Optional
 

--- a/src/tick_task/main.py
+++ b/src/tick_task/main.py
@@ -8,7 +8,6 @@ from fastapi.responses import RedirectResponse
 from tick_task.api import router as api_router
 from tick_task.auth import require_lan_token
 from tick_task.config import settings
-from tick_task.database import create_tables
 
 
 def create_application() -> FastAPI:

--- a/src/tick_task/models.py
+++ b/src/tick_task/models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import uuid4
 
-from sqlalchemy import Boolean, Column, DateTime, Enum, Integer, String, Text, func
+from sqlalchemy import DateTime, Enum, String, Text
 from sqlalchemy.dialects.sqlite import JSON
 from sqlalchemy.ext.asyncio import AsyncAttrs
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column

--- a/src/tick_task/schemas.py
+++ b/src/tick_task/schemas.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 from typing import Optional
-from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 


### PR DESCRIPTION
`main` is red. This makes it green without pretending the underlying debt is gone.

## What is actually broken

`quality-check` fails on **18 pre-existing mypy errors** — measured on `main` @ `e313a5b`, run [33475418017](https://github.com/Twin-Cities-Open-Systems/tick-task/actions/runs/33475418017).

They are not new, and they were not introduced by https://github.com/Twin-Cities-Open-Systems/tick-task/pull/42 or https://github.com/Twin-Cities-Open-Systems/tick-task/pull/43:

- `main`'s `.github/workflows/ci.yml` already ran `mypy src/ --ignore-missing-imports` with no `continue-on-error`.
- `main`'s `pyproject.toml` already set `disallow_untyped_defs`, `disallow_untyped_decorators`, `warn_return_any`, `check_untyped_defs`.
- Neither PR touched either.

They surfaced because **#42 is the first change that makes `pre-commit` pass**, so the type-checking step executed for the first time. `checked 9 source files` — the `auth.py` from #43 contributes zero errors.

## What this PR does

**1. `continue-on-error: true` on the type-checking step**, per PROMPTING_RULES rule 16 — never leave a check red on day one, because a permanently-red check trains people to ignore red. The reason *and* the flip condition are written into the workflow itself, not just here. Debt tracked in https://github.com/Twin-Cities-Open-Systems/tick-task/issues/44 with type/priority/effort set.

No target count in the flip condition, deliberately — new code changes it, and a hardcoded `18` would be wrong the moment anyone adds a function.

**2. Two config defects fixed rather than tracked**, because they are broken configuration rather than type debt, and mypy printed both on every single run:

- `python_version = "3.9"` is rejected outright by current mypy — `Python 3.9 is not supported (must be 3.10 or higher)`. Set to `"3.10"`, the lowest it accepts.
- A dead `[[tool.mypy.overrides]] module = ["alembic.*"]` block. `mypy src/` never walks `alembic/`, so mypy reported it as an unused section.

## The consequence worth reading

`requires-python` is still `>=3.9` and the classifiers still advertise 3.9, so with `python_version = "3.10"` **mypy no longer type-checks against the declared minimum**. Either drop 3.9 support and align `requires-python`/classifiers, or accept that 3.9-specific typing regressions go uncaught. That belongs in `docs/DECISIONS.md` as a real decision, not buried in a config comment — captured in #44.

## Verification

Not verified locally: mypy is not installed on this host. CI is the check. Expect `quality-check` to pass with the mypy step reporting its 18 errors as a non-fatal annotation, and the two `pyproject.toml` notices gone from the log.