### PR TITLE
feat(docker): real LAN-mode image, and restore the docker_build job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Build context hygiene. .git is excluded deliberately -- the version comes from
+# the VERSION build arg via SETUPTOOLS_SCM_PRETEND_VERSION, not from git history.
+.git
+.github
+frontend
+node_modules
+tests
+test_api.py
+alembic/versions/__pycache__
+**/__pycache__
+**/*.pyc
+.mypy_cache
+.pytest_cache
+.ruff_cache
+htmlcov
+.coverage
+*.egg-info
+build
+dist
+docs
+prompts
+scripts
+*.md
+!README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,3 +270,69 @@ jobs:
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'
+
+  # Restored 2026-09-01. Removed in 12e124d on the grounds that it "contradicts
+  # the recorded deployment decision" -- that read docs/DECISIONS.md line 220,
+  # whose Context is "How to distribute the application to end users". Docker was
+  # rejected there as an end-user distribution channel, alongside apt/brew/wheels.
+  # It says nothing about the LAN server shape docs/SPEC.md requires as
+  # MUST-API-002b, and the HEE release system lists Container as a peer format to
+  # PyInstaller. docs/ROADMAP.md keeps "Docker build successful" as a quality gate.
+  docker_build:
+    name: docker_build
+    runs-on: ubuntu-latest
+    needs: [backend_test, frontend_test]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # setuptools-scm needs history to derive a version.
+        fetch-depth: 0
+
+    - uses: docker/setup-buildx-action@v3
+
+    - name: Derive version for setuptools-scm
+      id: ver
+      run: echo "version=$(git describe --tags --always --dirty 2>/dev/null || echo 0.0.0+ci)" >> "$GITHUB_OUTPUT"
+
+    - name: Build image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        push: false
+        load: true
+        tags: tick-task:test
+        build-args: |
+          VERSION=${{ steps.ver.outputs.version }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    # The previous job ended in `|| true`, so it asserted nothing at all. These
+    # assert the two properties that actually matter for a LAN-mode image.
+    - name: Refuses to start without a LAN token
+      run: |
+        set +e
+        out="$(docker run --rm tick-task:test 2>&1)"; rc=$?
+        set -e
+        echo "$out"
+        if [ "$rc" -ne 78 ]; then
+          echo "::error::expected exit 78 (EX_CONFIG) with no token, got $rc"
+          exit 1
+        fi
+        echo "OK: refused unauthenticated start with exit 78"
+
+    - name: Serves health when a token is supplied
+      run: |
+        docker run -d --name tt -e TICK_TASK_LAN_TOKEN=ci-smoke-token -p 7000:7000 tick-task:test
+        for i in $(seq 1 30); do
+          if curl -fsS http://127.0.0.1:7000/api/v1/health >/dev/null 2>&1; then
+            echo "OK: health responded after ${i}s"
+            docker rm -f tt >/dev/null
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "::error::health endpoint never came up"
+        docker logs tt || true
+        docker rm -f tt >/dev/null || true
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,9 +290,27 @@ jobs:
 
     - uses: docker/setup-buildx-action@v3
 
+    # setuptools-scm requires a PEP 440 version. Raw `git describe` output is
+    # NOT one -- "v1.0.5-36-g01362f4" is rejected outright with
+    # "packaging.version.InvalidVersion", failing the build inside the image
+    # where the error is hard to read. Transform it here and validate it here,
+    # so a bad version fails at this step with an obvious message.
     - name: Derive version for setuptools-scm
       id: ver
-      run: echo "version=$(git describe --tags --always --dirty 2>/dev/null || echo 0.0.0+ci)" >> "$GITHUB_OUTPUT"
+      run: |
+        raw="$(git describe --tags --long --dirty 2>/dev/null || echo '')"
+        if [ -z "$raw" ]; then
+          ver="0.0.0+ci.$(git rev-parse --short HEAD)"
+        else
+          # v1.0.5-36-g01362f4[-dirty] -> 1.0.5.post36+g01362f4[.dirty]
+          # post-release form matches [tool.setuptools_scm] version_scheme.
+          ver="${raw#v}"
+          ver="$(printf '%s' "$ver" | sed -E 's/-([0-9]+)-g([0-9a-f]+)/.post\1+g\2/; s/-dirty/.dirty/')"
+        fi
+        python3 -c "from packaging.version import Version; Version('$ver')" \
+          || { echo "::error::derived version '$ver' is not PEP 440"; exit 1; }
+        echo "version=$ver" >> "$GITHUB_OUTPUT"
+        echo "derived version: $ver"
 
     - name: Build image
       uses: docker/build-push-action@v6
@@ -325,14 +343,24 @@ jobs:
       run: |
         docker run -d --name tt -e TICK_TASK_LAN_TOKEN=ci-smoke-token -p 7000:7000 tick-task:test
         for i in $(seq 1 30); do
-          if curl -fsS http://127.0.0.1:7000/api/v1/health >/dev/null 2>&1; then
+          if curl -fsS -H "Authorization: Bearer ci-smoke-token" \
+               http://127.0.0.1:7000/api/v1/health >/dev/null 2>&1; then
             echo "OK: health responded after ${i}s"
+            # And that it REFUSES an unauthenticated request. Without this the
+            # image could regress to serving open and still pass the check above.
+            code="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:7000/api/v1/health)"
+            if [ "$code" != "401" ]; then
+              echo "::error::unauthenticated request returned $code, expected 401"
+              docker rm -f tt >/dev/null
+              exit 1
+            fi
+            echo "OK: unauthenticated request refused with 401"
             docker rm -f tt >/dev/null
             exit 0
           fi
           sleep 1
         done
-        echo "::error::health endpoint never came up"
+        echo "::error::health endpoint never came up (with a valid token)"
         docker logs tt || true
         docker rm -f tt >/dev/null || true
         exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1
+
+# tick-task -- LAN-mode server image.
+#
+# This image serves the deployment shape docs/SPEC.md defines as MUST-API-002b:
+# the API bound to 0.0.0.0 behind token authentication, explicitly opted into.
+# It does NOT replace the desktop distribution path -- docs/DECISIONS.md chose
+# PyInstaller for handing the app to an end user, and that decision stands.
+# Container and PyInstaller are peer formats in the HEE release system's
+# packaging matrix (prompts/hee/docs/MODULES/RELEASE_SYSTEM.md), not
+# alternatives to each other.
+#
+# API only: the app mounts no static files and / redirects to /docs. The vite
+# frontend is not served from this image.
+
+ARG PYTHON_VERSION=3.12
+
+# --- build -------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim-bookworm AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+# The project version is dynamic via setuptools-scm, which reads git. The build
+# context has no .git, so without this the install fails outright. CI passes the
+# real version; the default keeps a bare "docker build ." working.
+ARG VERSION=0.0.0+docker
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+
+WORKDIR /src
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+COPY alembic.ini ./
+COPY alembic/ ./alembic/
+
+RUN python -m pip install --upgrade pip setuptools wheel \
+ && python -m pip install .
+
+# --- runtime -----------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:${PATH}"
+
+# A real service account, not root and not a world-writable directory.
+RUN groupadd --system --gid 10001 tick-task \
+ && useradd --system --uid 10001 --gid tick-task --home-dir /var/lib/tick-task \
+      --shell /usr/sbin/nologin tick-task
+
+COPY --from=builder /opt/venv /opt/venv
+COPY --chown=root:root docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/docker-entrypoint.sh
+
+# 0750: owner rwx, group rx, world nothing.
+RUN install -d -o tick-task -g tick-task -m 0750 /var/lib/tick-task
+VOLUME ["/var/lib/tick-task"]
+
+# 0.0.0.0 is not a policy choice here -- a container is unreachable otherwise.
+# The token guard in the entrypoint is what keeps that bind from being open.
+ENV TICK_TASK_HOST=0.0.0.0 \
+    TICK_TASK_PORT=7000 \
+    TICK_TASK_LAN_MODE=true \
+    TICK_TASK_DATA_DIR=/var/lib/tick-task \
+    TICK_TASK_DATABASE_URL=sqlite+aiosqlite:////var/lib/tick-task/tick-task.db
+
+USER tick-task
+WORKDIR /var/lib/tick-task
+EXPOSE 7000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:7000/api/v1/health', timeout=4).status == 200 else 1)"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["tick-task"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,11 @@ USER tick-task
 WORKDIR /var/lib/tick-task
 EXPOSE 7000
 
+# The health endpoint is authenticated: require_lan_token guards every route
+# when lan_mode is on, so an unauthenticated probe gets 401 and the container
+# would report unhealthy forever. Send the token the same way a client does.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD python -c "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:7000/api/v1/health', timeout=4).status == 200 else 1)"
+  CMD python -c "import os,sys,urllib.request as u; r=u.Request('http://127.0.0.1:7000/api/v1/health', headers={'Authorization': 'Bearer ' + os.environ.get('TICK_TASK_LAN_TOKEN','')}); sys.exit(0 if u.urlopen(r, timeout=4).status == 200 else 1)"
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["tick-task"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# tick-task container entrypoint -- refuses to serve an unauthenticated bind.
+#
+# The image sets TICK_TASK_HOST=0.0.0.0 because a container is unreachable
+# otherwise. docs/SPEC.md MUST-API-002b requires that any non-localhost bind be
+# token-authenticated, so starting without a token would ship exactly the
+# exposure the spec forbids. Fail closed instead, and say why.
+#
+# This guard is deliberately independent of the application's own lan_mode
+# enforcement: it holds whether or not the auth work in PR 43 has merged, so
+# merge order cannot leave an open image.
+
+set -eu
+
+if [ -z "${TICK_TASK_LAN_TOKEN:-}" ]; then
+    echo "CRITICAL: TICK_TASK_LAN_TOKEN is not set." >&2
+    echo "" >&2
+    echo "This image binds ${TICK_TASK_HOST:-0.0.0.0}:${TICK_TASK_PORT:-7000}, which docs/SPEC.md" >&2
+    echo "(MUST-API-002b) requires to be token-authenticated. Refusing to start" >&2
+    echo "rather than serve unauthenticated on every interface." >&2
+    echo "" >&2
+    echo "Generate a token and pass it in, for example:" >&2
+    echo "  docker run -e TICK_TASK_LAN_TOKEN=\"\$(python3 -c 'import secrets;print(secrets.token_urlsafe(32))')\" ..." >&2
+    exit 78   # EX_CONFIG
+fi
+
+# Token present but empty-after-trim is the same failure wearing a disguise.
+case "${TICK_TASK_LAN_TOKEN}" in
+    *[!\ ]*) : ;;
+    *) echo "CRITICAL: TICK_TASK_LAN_TOKEN is set but blank." >&2; exit 78 ;;
+esac
+
+exec "$@"


### PR DESCRIPTION
Reverses `12e124d`, which removed `docker_build` on the grounds that it *"contradicts the recorded deployment decision"*. That reading does not survive checking the decision.

## Docker was rejected as an end-user channel, not as a server format

`/home/claude/git/tick-task/docs/DECISIONS.md` line 220 does list Docker under **Alternatives Considered** — but its **Context** line is *"How to distribute the application to end users"*. Docker was rejected there alongside apt, brew and wheels. PyInstaller won that row and still does. Nothing in this PR changes that.

It says nothing about the *other* deployment shape this project has:

| Shape | Mechanism | Recorded in |
|---|---|---|
| Desktop end-user | PyInstaller single binary | `docs/DECISIONS.md:220` |
| LAN server | binds `0.0.0.0` + token auth | `docs/SPEC.md:216` — **MUST-API-002b** |

`docs/OPERATIONS.md:55` documents LAN mode as an explicit opt-in operating mode. `prompts/hee/docs/MODULES/RELEASE_SYSTEM.md:145` lists **Docker Image / Container** as a *peer* of the PyInstaller, macOS and AppImage rows — not an alternative to them. And `docs/ROADMAP.md:405` still carries **"Docker build successful"** as a quality gate.

So the missing artifact was the **Dockerfile**, not the job.

## The image

- **Multi-stage**, `python:3.12-slim-bookworm`. Runs as a real service account, `uid/gid 10001`, never root. Data dir is `0750` — not world-anything.
- **Binds `0.0.0.0`** because a container is unreachable otherwise — **and the entrypoint refuses to start without `TICK_TASK_LAN_TOKEN`**, exiting `78` (`EX_CONFIG`). That guard is deliberately independent of the app's own `lan_mode` enforcement, so no merge order can leave an image serving unauthenticated on every interface.
- **`VERSION` build arg → `SETUPTOOLS_SCM_PRETEND_VERSION`.** The version is dynamic via setuptools-scm, which reads git; without this, `pip install .` fails in a context with no `.git`. **The old `docker_build` job would have failed on this too**, even had a Dockerfile existed.
- **API only.** The app mounts no static files and `/` redirects to `/docs`. The vite frontend is not served from this image.

## The job now asserts something

The previous smoke test ended in `|| true` and could not fail. This one checks the two properties that actually matter:

1. the image **refuses** an unauthenticated start with exit `78`
2. it **answers** `/api/v1/health` once a token is supplied

Tag corrected from `fin-tasks:test` — the project's former name — to `tick-task:test`.

## Verified locally on kiosk before commit

```
PASS: refused unauthenticated start (exit 78)
{"status":"healthy","version":"0.4.0","database":"connected", ...}
PASS: health responded after 3s
uid=10001(tick-task) gid=10001(tick-task) groups=10001(tick-task)
```

## Expected CI state

`quality-check` will be **red on this branch** — that is the 18 pre-existing mypy errors, fixed separately in https://github.com/Twin-Cities-Open-Systems/tick-task/pull/45. Not caused by this PR, and independent of it.

## Found in passing, not fixed here

`/home/claude/git/tick-task/src/tick_task/_version.py` is generated by setuptools-scm, is **committed to git**, carries the header *"don't change, don't track in version control"*, and has no `.gitignore` rule. That committed copy is what overrode the build arg and produced `0.4.0` above. Derived state in git — worth its own change.